### PR TITLE
Cursor now snaps to the typed characters and scrolling

### DIFF
--- a/editor/action.go
+++ b/editor/action.go
@@ -20,7 +20,7 @@ type EraseCharAction struct{}
 
 func (action EraseCharAction) execute(state *EditorState) {
 	move_back_cursor(state)
-	putchar_at_cursor(state, ' ')
+	// putchar_at_cursor(state, ' ')
 	remove_symbol(state, state.cursor)
 }
 
@@ -61,7 +61,7 @@ func (action MoveCursorAction) execute(state *EditorState) {
 	case MoveDown:
 		move_down_cursor(state)
 	case MoveUp:
-		move_up_cursor(&state.cursor)
+		move_up_cursor(state)
 	}
 }
 
@@ -72,7 +72,7 @@ type EnterCharAction struct {
 func (action EnterCharAction) execute(state *EditorState) {
 	record_rune(state, state.cursor, action.r)
 
-	putchar_at_cursor(state, action.r)
+	// putchar_at_cursor(state, action.r)
 	move_right_cursor(state)
 }
 

--- a/editor/cursor.go
+++ b/editor/cursor.go
@@ -1,16 +1,51 @@
 package main
 
+import "log"
+
+// Scroll the screen down
+func scroll_down(state *EditorState) {
+	if state.upper_bound >= len(state.text) {
+		return
+	}
+
+	state.upper_bound++
+}
+
+// Scroll the screen up
+func scroll_up(state *EditorState) {
+	if state.upper_bound == 0 {
+		return
+	}
+
+	state.upper_bound--
+}
+
 // Move the cursor 1 cell to the right
 func move_right_cursor(state *EditorState) {
-	state.cursor.x++
+	if state.cursor.x+1 >= len(state.text[state.cursor.y]) {
+		old_pos := state.cursor
+
+		var e error
+		state.cursor, e = find_next_char(state, state.cursor)
+
+		if e != nil {
+			log.Print(e)
+			state.cursor = old_pos
+		}
+		return
+	} else {
+		state.cursor.x++
+	}
+
 	screen_x, screen_y := state.screen.Size()
 
 	if state.cursor.x > screen_x {
 		state.cursor.x = 1
 		state.cursor.y++
 	}
-	if state.cursor.y > screen_y {
-		// TODO: the screen should scroll down here
+	if state.cursor.y >= screen_y {
+		scroll_down(state)
+		state.cursor.y--
 	}
 }
 
@@ -22,27 +57,47 @@ func move_back_cursor(state *EditorState) {
 		state.cursor.x = 0
 	} else if state.cursor.x < 0 {
 		state.cursor.y--
-		state.cursor.x = find_last_char(state.screen, state.cursor.y)
+		state.cursor.x = find_last_char(state, state.cursor.y)
+	}
+
+	if state.cursor.y < state.upper_bound {
+		scroll_up(state)
+		state.cursor.y = 0
 	}
 }
 
 // Move the cursor one cell up.
-func move_up_cursor(cursor *Vec2) {
-	cursor.y--
-
-	if cursor.y < 0 {
-		cursor.y = 0
+func move_up_cursor(state *EditorState) {
+	if state.cursor.y <= 0 {
+		scroll_up(state)
+		return
 	}
+	if state.cursor.y < 0 {
+		state.cursor.y = 0
+		return
+	}
+
+	if state.cursor.x >= len(state.text[state.cursor.y-1]) ||
+		state.text[state.cursor.y-1][state.cursor.x] == ' ' {
+		state.cursor.x = find_last_char(state, state.cursor.y-1)
+	}
+	state.cursor.y--
 }
 
-// Move the cursor one cell up.
+// Move the cursor one cell down.
 func move_down_cursor(state *EditorState) {
-	state.cursor.y++
-
-	screen_y, _ := state.screen.Size()
+	_, screen_y := state.screen.Size()
 	if state.cursor.y >= screen_y {
+		scroll_down(state)
 		state.cursor.y--
+		return
 	}
+
+	if state.cursor.x >= len(state.text[state.cursor.y+1]) ||
+		state.text[state.cursor.y+1][state.cursor.x] == ' ' {
+		state.cursor.x = find_first_char(state, state.cursor.y+1)
+	}
+	state.cursor.y++
 }
 
 // Updates the cursor's coordinates.

--- a/editor/gim.go
+++ b/editor/gim.go
@@ -21,9 +21,8 @@ type EditorState struct {
 	filename      string
 	actions       []Action
 	text          []string
+	upper_bound   int // The line from which to start drawing text
 }
-
-var g_last_key_pressed tcell.Key
 
 func add_action(state *EditorState, action Action) {
 	state.actions = append(state.actions, action)
@@ -36,13 +35,17 @@ func execute_actions(state *EditorState) {
 	}
 }
 
+// Draws the recorded text to the screen,
+// starting from the line number `upper_bound`
 func show_text(state *EditorState) {
-	for y := range state.text {
-		for x, r := range state.text[y] {
+	for y := range state.text[state.upper_bound:] {
+		for x, r := range state.text[y+state.upper_bound] {
 			PutChar(state.screen, x, y, state.default_style, r)
 		}
 	}
 }
+
+var g_last_key_pressed tcell.Key
 
 func handle_events(state *EditorState) {
 	event := state.screen.PollEvent()
@@ -136,6 +139,7 @@ func main() {
 		screen:        screen,
 		actions:       make([]Action, 0),
 		text:          make([]string, 0),
+		upper_bound:   0,
 	}
 
 	parse_args(&state)

--- a/editor/render.go
+++ b/editor/render.go
@@ -3,6 +3,8 @@ package main
 
 import "github.com/gdamore/tcell/v2"
 
+// var g_tab_width = 4
+
 // Draw 'text' in the box defined by 'x1, y1' and 'x2, y2'
 // on the 'screen' with 'style'
 func DrawText(screen tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, text string) {
@@ -22,5 +24,11 @@ func DrawText(screen tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, text s
 }
 
 func PutChar(screen tcell.Screen, x, y int, style tcell.Style, character rune) {
+	// if character == '\t' {
+	// 	for i := 0; i < g_tab_width; i++ {
+	// 		screen.SetContent(x+i, y, ' ', nil, style)
+	// 	}
+	// 	return
+	// }
 	screen.SetContent(x, y, character, nil, style)
 }


### PR DESCRIPTION
- When moving the cursor up, down it snaps to the existing characters.
- When transitioning to a new line by moving to the right or to the left
it also snaps to the characters.
- Added scrolling.
- Refactored `find_last_char`. Added two new text manipulating
  functions.
- `move_up_cursor` now takes `*EditorState` instead of `Vec2'
- Commented out unnecessary `putchar` calls.